### PR TITLE
GitHub Actions: Add ubuntu-24.04-arm to the testing

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,10 +12,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-latest]
         version: [release, master, "${{ vars.SPECIFIED_VERSION }}", "${{ vars.SPECIFIED_VERSION_MACOS }}"]
         exclude:
           - os: ubuntu-latest
+            version: ${{ vars.SPECIFIED_VERSION_MACOS }}
+          - os: ubuntu-24.04-arm
             version: ${{ vars.SPECIFIED_VERSION_MACOS }}
           - os: windows-latest
             version: ${{ vars.SPECIFIED_VERSION_MACOS }}


### PR DESCRIPTION
[Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `os: ubuntu-24.04-arm`